### PR TITLE
Ups the two-handed aim tolerance a bit.

### DIFF
--- a/RoR2VRMod/TwoHandedOrigin.cs
+++ b/RoR2VRMod/TwoHandedOrigin.cs
@@ -9,7 +9,7 @@ namespace VRMod
         internal bool twoHandedAimActive = true;
 
         [SerializeField]
-        private float angleTolerance = 40f;
+        private float angleTolerance = 60f;
 
         [SerializeField]
         private Transform originTransform;


### PR DESCRIPTION
Had a lot of instances with the two handed hold on Bandit's shotgun disabling while I was mid shot, figure making the accepted distance a little bigger might make it feel better. Probably should be tested. Maybe 50f instead of 60f?