### PR TITLE
Fix controller movement handling for flying

### DIFF
--- a/RoR2VRMod/Inputs/Controllers.cs
+++ b/RoR2VRMod/Inputs/Controllers.cs
@@ -283,6 +283,15 @@ namespace VRMod
                 return Quaternion.Euler(new Vector3(0, 0, angleDifference)) * vector;
             });
             c.Emit(OpCodes.Stloc_S, (byte)6);
+
+            c.GotoNext(x => x.MatchCallvirt<Transform>("get_right"));
+            c.Index += 1;
+            c.EmitDelegate<Func<Vector3, Vector3>>((vector) =>
+            {
+                if (!ModConfig.ControllerMovementDirection.Value || !MotionControls.HandsReady) return vector;
+                // In flight mode, clamp the controller's left-right vector to the xz plane (normal to Vector3.up) so that only pitch and yaw are affected, not roll.
+                return Vector3.ProjectOnPlane(vector, Vector3.up).normalized * vector.magnitude;
+            });
         }
 
         private static void ShowRecenterDialog(On.RoR2.UI.MainMenu.MainMenuController.orig_Start orig, RoR2.UI.MainMenu.MainMenuController self)

--- a/RoR2VRMod/Inputs/Controllers.cs
+++ b/RoR2VRMod/Inputs/Controllers.cs
@@ -247,33 +247,38 @@ namespace VRMod
         {
             ILCursor c = new ILCursor(il);
 
+            c.GotoNext(x => x.MatchStloc(5));
+            c.EmitDelegate<Func<Transform, Transform>>((headTransform) =>
+            {
+                if (!ModConfig.ControllerMovementDirection.Value) return headTransform;
+
+                if (MotionControls.HandsReady)
+                {
+                    // If controller movement tracking is enabled, replace the base camera transform with the controller transform.
+                    return MotionControls.GetHandByDominance(false).muzzle.transform;
+                }
+                else
+                {
+                    // See below for handling of the case where hands are not ready.
+                    return headTransform;
+                }
+            });
+
             c.GotoNext(x => x.MatchLdloca(6));
             c.GotoNext(x => x.MatchLdloca(6));
 
             c.Emit(OpCodes.Ldloc_S, (byte)6);
             c.EmitDelegate<Func<Vector2, Vector2>>((vector) =>
             {
-                if (!ModConfig.ControllerMovementDirection.Value) return vector;
+                if (!ModConfig.ControllerMovementDirection.Value || MotionControls.HandsReady) return vector;
 
-                float angleDifference;
+                // Special case only for if hands are not ready; in this case, we can't assume a hand transform exists, so we fall back to old logic.
+                // Note: this will only provide y-axis rotation (yaw); z-axis rotation (pitch) will still be controlled by the head.
+                
+                Quaternion controllerRotation = InputTracking.GetLocalRotation(XRNode.LeftHand);
+                Quaternion headRotation = Camera.main.transform.localRotation;
 
-                if (MotionControls.HandsReady)
-                {
-                    Vector3 controllerDirection = MotionControls.GetHandByDominance(false).muzzle.forward;
-                    Vector3 cameraDirection = Camera.main.transform.forward;
-
-                    controllerDirection.y = 0;
-                    cameraDirection.y = 0;
-
-                    angleDifference = Vector3.SignedAngle(controllerDirection, cameraDirection, Vector3.up);
-                }
-                else
-                {
-                    Quaternion controllerRotation = InputTracking.GetLocalRotation(XRNode.LeftHand);
-                    Quaternion headRotation = Camera.main.transform.localRotation;
-
-                    angleDifference = headRotation.eulerAngles.y - controllerRotation.eulerAngles.y;
-                }
+                float angleDifference = headRotation.eulerAngles.y - controllerRotation.eulerAngles.y;
 
                 return Quaternion.Euler(new Vector3(0, 0, angleDifference)) * vector;
             });


### PR DESCRIPTION
This PR addresses [issue 64](https://github.com/DrBibop/RoR2VRMod/issues/64).

In the base RoR2 code, the movement input x and y components are used to create a `Vector2`, which is then used to rotate the camera's `Transform`'s y component. The result is a movement vector calculated by taking the camera direction (a `Transform`) and rotating it by the movement input (a `Vector2`).

Currently, the CIL patch for controller movement handling in this mod works by rotating the *movement input vector* by an amount calculated based on the angle difference between the headset and controller vectors (both having been projected onto the xz plane).

This reworks the patch to instead just directly swap out the camera's `Transform` for the off-hand controller's `Transform`. No rotational difference calculations necessary!

(Note: the case of `!HandsReady` does not allow this solution, as no transform can be assumed to exist in that case AFAIK; I've just kept that specific branch of the old patch around to support that case.)

This change was lightly tested on my Vive running the latest version of RoR2, but it'd probably be a good idea to test it more thoroughly before merging this PR.