### PR TITLE
Add extra Railgunner config options

### DIFF
--- a/RoR2VRMod/MotionControls/HandComponents/SniperScopeController.cs
+++ b/RoR2VRMod/MotionControls/HandComponents/SniperScopeController.cs
@@ -225,7 +225,13 @@ namespace VRMod
 
         private void OnDisable()
         {
-            scopeViewRenderer.material = clearMaterial;
+            if (!ModConfig.RailgunnerKeepScopeVisible.Value)
+            {
+                scopeViewRenderer.material = clearMaterial;
+            } else
+            {
+                this.enabled = true;
+            }
         }
 
         private void LateUpdate()

--- a/RoR2VRMod/MotionControls/MotionControlledAbilities.cs
+++ b/RoR2VRMod/MotionControls/MotionControlledAbilities.cs
@@ -203,8 +203,9 @@ namespace VRMod
             On.EntityStates.Captain.Weapon.FireTazer.Fire += ChangeTazerMuzzleShoot;
 
             On.EntityStates.Railgunner.Scope.BaseWindUp.OnEnter += SetScopeFOV;
-            On.EntityStates.Railgunner.Scope.BaseScopeState.OnEnter += RemoveOverlay;
+            On.EntityStates.Railgunner.Scope.BaseScopeState.OnEnter += RemoveScopeCritOverlay;
             On.EntityStates.Railgunner.Weapon.BaseFireSnipe.OnEnter += ChangeSniperMuzzle;
+            IL.EntityStates.Railgunner.Reload.Waiting.CanReload += AllowReloadWhileScoped;
 
             On.EntityStates.VoidSurvivor.VoidBlinkBase.OnEnter += ChangeBlinkDirection;
 
@@ -221,7 +222,7 @@ namespace VRMod
             orig(self);
         }
 
-        private static void RemoveOverlay(On.EntityStates.Railgunner.Scope.BaseScopeState.orig_OnEnter orig, EntityStates.Railgunner.Scope.BaseScopeState self)
+        private static void RemoveScopeCritOverlay(On.EntityStates.Railgunner.Scope.BaseScopeState.orig_OnEnter orig, EntityStates.Railgunner.Scope.BaseScopeState self)
         {
             Transform overlay = self.scopeOverlayPrefab.transform.Find("ScopeOverlay");
 
@@ -233,10 +234,22 @@ namespace VRMod
             {
                 self.overlayController.onInstanceAdded += (controller, instance) =>
                 {
-                    GetHandByDominance(true).currentHand.GetComponent<SniperScopeController>().SetOverlay(instance);
+                    if(!ModConfig.RailgunnerShowCritTargetsInWorld.Value) GetHandByDominance(true).currentHand.GetComponent<SniperScopeController>().SetOverlay(instance);
                 };
                 return;
             }
+        }
+
+        private static void AllowReloadWhileScoped(ILContext il)
+        {
+            ILCursor c = new ILCursor(il);
+
+            c.GotoNext(x => x.MatchCallvirt<EntityStateMachine>("IsInMainState"));
+            c.Index += 1;
+            c.EmitDelegate<Func<bool, bool>>((orig) =>
+            {
+                return ModConfig.RailgunnerReloadWhileScoped.Value || orig;
+            });
         }
 
         private static void SetScopeFOV(On.EntityStates.Railgunner.Scope.BaseWindUp.orig_OnEnter orig, EntityStates.Railgunner.Scope.BaseWindUp self)

--- a/RoR2VRMod/MotionControls/MotionControlledAbilities.cs
+++ b/RoR2VRMod/MotionControls/MotionControlledAbilities.cs
@@ -203,7 +203,7 @@ namespace VRMod
             On.EntityStates.Captain.Weapon.FireTazer.Fire += ChangeTazerMuzzleShoot;
 
             On.EntityStates.Railgunner.Scope.BaseWindUp.OnEnter += SetScopeFOV;
-            On.EntityStates.Railgunner.Scope.BaseScopeState.OnEnter += RemoveScopeCritOverlay;
+            On.EntityStates.Railgunner.Scope.BaseScopeState.OnEnter += RemoveScopeOverlay;
             On.EntityStates.Railgunner.Weapon.BaseFireSnipe.OnEnter += ChangeSniperMuzzle;
             IL.EntityStates.Railgunner.Reload.Waiting.CanReload += AllowReloadWhileScoped;
 
@@ -222,7 +222,7 @@ namespace VRMod
             orig(self);
         }
 
-        private static void RemoveScopeCritOverlay(On.EntityStates.Railgunner.Scope.BaseScopeState.orig_OnEnter orig, EntityStates.Railgunner.Scope.BaseScopeState self)
+        private static void RemoveScopeOverlay(On.EntityStates.Railgunner.Scope.BaseScopeState.orig_OnEnter orig, EntityStates.Railgunner.Scope.BaseScopeState self)
         {
             Transform overlay = self.scopeOverlayPrefab.transform.Find("ScopeOverlay");
 

--- a/RoR2VRMod/Settings/ModConfig.cs
+++ b/RoR2VRMod/Settings/ModConfig.cs
@@ -32,6 +32,9 @@ namespace VRMod
         internal static ConfigEntry<float> RailgunnerWeaponGripSnapAngle { get; private set; }
         internal static ConfigEntry<float> RailgunnerZoomMultiplier { get; private set; }
         internal static ConfigEntry<bool> RailgunnerDisableScopeRay { get; private set; }
+        internal static ConfigEntry<bool> RailgunnerKeepScopeVisible { get; private set; }
+        internal static ConfigEntry<bool> RailgunnerShowCritTargetsInWorld { get; private set; }
+        internal static ConfigEntry<bool> RailgunnerReloadWhileScoped { get; private set; }
         internal static Color RayColor = Color.white;
 
         internal static ConfigEntry<bool> WristHUD { get; private set; }
@@ -162,6 +165,24 @@ namespace VRMod
                 "Railgunner: Hide ray while scoping",
                 false,
                 "Disables the aim ray while using the scope. Enable this setting if you find it obstructs the scope too much... or if you're a gamer and think no scopes should be harder."
+            );
+            RailgunnerKeepScopeVisible = configFile.Bind<bool>(
+                "Survivor Settings",
+                "Railgunner: Keep scope visible when not scoping",
+                false,
+                "Keeps the scope view visible all the time, not just while sniping."
+            );
+            RailgunnerShowCritTargetsInWorld = configFile.Bind<bool>(
+                "Survivor Settings",
+                "Railgunner: Show critical hit targets in the world",
+                false,
+                "Displays critical hit boxes on enemies in the world rather than through the scope."
+            );
+            RailgunnerReloadWhileScoped = configFile.Bind<bool>(
+                "Survivor Settings",
+                "Railgunner: Reload while scoped",
+                false,
+                "Allows Railgunner to reload even while scoped."
             );
 
             RayColor = HexToColor(RayColorHex.Value);
@@ -322,6 +343,9 @@ namespace VRMod
             settings.Add("vr_railgunner_angle", new ConfigSetting(RailgunnerWeaponGripSnapAngle, 0, 180, ConfigSetting.SettingUpdate.Instant, MotionControls.UpdateRailgunnerSnapAngle));
             settings.Add("vr_railgunner_zoom", new ConfigSetting(RailgunnerZoomMultiplier, 2, 4, ConfigSetting.SettingUpdate.Instant));
             settings.Add("vr_railgunner_scoperay", new ConfigSetting(RailgunnerDisableScopeRay, ConfigSetting.SettingUpdate.Instant));
+            settings.Add("vr_railgunner_scopevisible", new ConfigSetting(RailgunnerKeepScopeVisible, ConfigSetting.SettingUpdate.Instant));
+            settings.Add("vr_railgunner_crit_targets", new ConfigSetting(RailgunnerShowCritTargetsInWorld, ConfigSetting.SettingUpdate.Instant));
+            settings.Add("vr_railgunner_reloadscoped", new ConfigSetting(RailgunnerReloadWhileScoped, ConfigSetting.SettingUpdate.Instant));
             settings.Add("vr_hud_width", new ConfigSetting(HUDWidth, 400, 2400, ConfigSetting.SettingUpdate.Instant, ChangeHUDSize));
             settings.Add("vr_hud_height", new ConfigSetting(HUDHeight, 400, 2400, ConfigSetting.SettingUpdate.Instant, ChangeHUDSize));
             settings.Add("vr_anchor_bottom", new ConfigSetting(BottomAnchor, 0, 1, ConfigSetting.SettingUpdate.Instant, ChangeHUDAnchors));


### PR DESCRIPTION
It's been frustrating me how using Railgunner's scope in VR means I can't track targets when descoping to reload (unlike in non-VR, when I can still track targets when zoomed out, since the reticle doesn't move around like my arms do).

I had three ideas for how to solve this issue:

1. Keep the scope view active when not in sniping mode, so I can keep a bead on enemies while reloading.
2. Display crit boxes in the world instead of through the scope, so I don't need to look down the scope and can use the scope ray instead.
3. Allow Railgunner to reload while scoped.

This PR adds all three! Each has its own setting in the config file, and each setting controls three specific small code changes. Keeping the scope active is much nicer on my Vive grip buttons.